### PR TITLE
Business Website Builder

### DIFF
--- a/src/technologies/b.json
+++ b/src/technologies/b.json
@@ -2398,6 +2398,14 @@
     "scriptSrc": "CatalystScripts",
     "website": "http://businesscatalyst.com"
   },
+  "Business Website Builder": {
+    "cats": [
+      1
+    ],
+    "icon": "Google.svg",
+    "url": "https?://[^.]+\\.business\\.page",
+    "website": "https://businesswebsites.google.com/welcome"
+  },
   "ButterCMS": {
     "cats": [
       1


### PR DESCRIPTION
Adds support for Google's [Business Website Builder](https://businesswebsites.google.com/welcome) CMS.

This is similar to the existing [Google My Business](https://github.com/wappalyzer/wappalyzer/blob/ee4d835aea6f1ab0432e07883b05dd6a9fd5200b/src/technologies/g.json#L1553-L1560) detection. The distinction is that that one matches subdomains of business.site while this one is business.page. They're separate CMSs.

Note that, unlike the other one, the name for this technology does not officially start with "Google". The full name is "Business Website Builder".

Some example URLs that use this technology:

- https://datang.business.page/
- https://foodadditive.business.page/
- https://times-marine.business.page/
- https://naturalorchid.business.page/
- https://icemachine.business.page/